### PR TITLE
Added libs in libraries/ to the include path

### DIFF
--- a/support/make/build-templates.mk
+++ b/support/make/build-templates.mk
@@ -1,5 +1,6 @@
 define LIBMAPLE_MODULE_template
 dir := $(1)
+LIBMAPLE_INCLUDES += -I$$(dir)
 include $$(dir)/rules.mk
 endef
 


### PR DESCRIPTION
- This allows to including of libs headers eg:
  
    #include <Servo.h>
  
  which wasn't possible for some reason.
