### PR TITLE
USART on heap

### DIFF
--- a/libmaple/heap.c
+++ b/libmaple/heap.c
@@ -1,0 +1,73 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2011 Michael Hope <michaelh@juju.net.nz>
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+/**
+ *  @file heap.c
+ *
+ *  @brief Very simple allocate-only heap.
+ */
+
+#include "heap.h"
+
+#define STACK_RESERVED_BYTES 1024
+
+extern uint8 _end;
+extern uint8 __stack_end;
+
+/**
+ * @brief Allocate a number of bytes from the heap.
+ *
+ * Result is word aligned.  Memory cannot be returned.
+ *
+ * @param nbytes  number of bytes to allocate
+ * @return        start of the region, or NULL on OOM
+ */
+void *heap_alloc(uint32 nbytes) {
+    /* This is a trial implementation.  It's equivalent to sbrk() and
+       overlaps.  Lets hope Newlib's malloc() is never called.
+    */
+
+    /* Design-wise, returning NULL is poor.  It's better to halt the
+       system here.
+    */
+
+    /* Would be nice to have a system mode and fault if you allocate
+       memory past initial initialisation.
+    */
+
+    static uint8 *pbreak = &_end;
+
+    uint8 *pnext = pbreak + ((nbytes + 3) & ~3);
+
+    if (pnext >= &__stack_end - STACK_RESERVED_BYTES) {
+        return NULL;
+    }
+
+    uint8 *pat = pbreak;
+    pbreak = pnext;
+
+    return pat;
+}

--- a/libmaple/heap.h
+++ b/libmaple/heap.h
@@ -1,0 +1,48 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2011 Michael Hope <michaelh@juju.net.nz>
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+/**
+ *  @file heap.h
+ *
+ *  @brief Very simple allocate-only heap.
+ */
+
+#ifndef _HEAP_H_
+#define _HEAP_H_
+
+#include "libmaple_types.h"
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+void *heap_alloc(uint32 nbytes);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/libmaple/usart.c
+++ b/libmaple/usart.c
@@ -32,13 +32,20 @@
  */
 
 #include "usart.h"
+#include "heap.h"
+
+#ifndef USART_RX_BUF_SIZE
+/* Default receive buffer size.  Could be shifted to link time
+   configuration. */
+#define USART_RX_BUF_SIZE               64
+#endif
 
 /*
  * Devices
  */
 
 static ring_buffer usart1_rb;
-static usart_dev usart1 = {
+static const usart_dev usart1 = {
     .regs     = USART1_BASE,
     .rb       = &usart1_rb,
     .max_baud = 4500000UL,
@@ -46,10 +53,10 @@ static usart_dev usart1 = {
     .irq_num  = NVIC_USART1
 };
 /** USART1 device */
-usart_dev *USART1 = &usart1;
+usart_dev * const USART1 = &usart1;
 
 static ring_buffer usart2_rb;
-static usart_dev usart2 = {
+static const usart_dev usart2 = {
     .regs     = USART2_BASE,
     .rb       = &usart2_rb,
     .max_baud = 2250000UL,
@@ -57,10 +64,10 @@ static usart_dev usart2 = {
     .irq_num  = NVIC_USART2
 };
 /** USART2 device */
-usart_dev *USART2 = &usart2;
+usart_dev * const USART2 = &usart2;
 
 static ring_buffer usart3_rb;
-static usart_dev usart3 = {
+static const usart_dev usart3 = {
     .regs     = USART3_BASE,
     .rb       = &usart3_rb,
     .max_baud = 2250000UL,
@@ -68,11 +75,11 @@ static usart_dev usart3 = {
     .irq_num  = NVIC_USART3
 };
 /** USART3 device */
-usart_dev *USART3 = &usart3;
+usart_dev * const USART3 = &usart3;
 
 #ifdef STM32_HIGH_DENSITY
 static ring_buffer uart4_rb;
-static usart_dev uart4 = {
+static const usart_dev uart4 = {
     .regs     = UART4_BASE,
     .rb       = &uart4_rb,
     .max_baud = 2250000UL,
@@ -80,10 +87,10 @@ static usart_dev uart4 = {
     .irq_num  = NVIC_UART4
 };
 /** UART4 device */
-usart_dev *UART4 = &uart4;
+usart_dev * const UART4 = &uart4;
 
 static ring_buffer uart5_rb;
-static usart_dev uart5 = {
+static const usart_dev uart5 = {
     .regs     = UART5_BASE,
     .rb       = &uart5_rb,
     .max_baud = 2250000UL,
@@ -91,7 +98,7 @@ static usart_dev uart5 = {
     .irq_num  = NVIC_UART5
 };
 /** UART5 device */
-usart_dev *UART5 = &uart5;
+usart_dev * const UART5 = &uart5;
 #endif
 
 /**
@@ -99,7 +106,16 @@ usart_dev *UART5 = &uart5;
  * @param dev         Serial port to be initialized
  */
 void usart_init(usart_dev *dev) {
-    rb_init(dev->rb, USART_RX_BUF_SIZE, dev->rx_buf);
+    usart_init_ex(dev, USART_RX_BUF_SIZE);
+}
+
+/**
+ * @brief Initialize a serial port.
+ * @param dev  Serial port to be initialized
+ * @param rx_size  Size of the receive buffer in bytes
+ */
+void usart_init_ex(usart_dev *dev, uint32 rx_size) {
+    rb_init(dev->rb, USART_RX_BUF_SIZE, heap_alloc(USART_RX_BUF_SIZE));
     rcc_clk_enable(dev->clk_id);
     nvic_irq_enable(dev->irq_num);
 }

--- a/libmaple/usart.h
+++ b/libmaple/usart.h
@@ -228,29 +228,27 @@ typedef struct usart_reg_map {
  * Devices
  */
 
-#ifndef USART_RX_BUF_SIZE
-#define USART_RX_BUF_SIZE               64
-#endif
-
 /** USART device type */
-typedef struct usart_dev {
+struct usart_dev {
     usart_reg_map *regs;             /**< Register map */
     ring_buffer *rb;                 /**< RX ring buffer */
     uint32 max_baud;                 /**< Maximum baud */
-    uint8 rx_buf[USART_RX_BUF_SIZE]; /**< Actual RX buffer used by rb */
     rcc_clk_id clk_id;               /**< RCC clock information */
     nvic_irq_num irq_num;            /**< USART NVIC interrupt */
-} usart_dev;
+};
 
-extern usart_dev *USART1;
-extern usart_dev *USART2;
-extern usart_dev *USART3;
+typedef const struct usart_dev usart_dev;
+
+extern usart_dev * const USART1;
+extern usart_dev * const USART2;
+extern usart_dev * const USART3;
 #ifdef STM32_HIGH_DENSITY
-extern usart_dev *UART4;
-extern usart_dev *UART5;
+extern usart_dev * const UART4;
+extern usart_dev * const UART5;
 #endif
 
 void usart_init(usart_dev *dev);
+void usart_init_ex(usart_dev *dev, uint32 rx_size);
 void usart_set_baud_rate(usart_dev *dev, uint32 clock_speed, uint32 baud);
 void usart_enable(usart_dev *dev);
 void usart_disable(usart_dev *dev);

--- a/libmaple/util.h
+++ b/libmaple/util.h
@@ -48,7 +48,7 @@ extern "C"{
 #define BIT_MASK_SHIFT(mask, shift)    ((mask) << (shift))
 /** Bits m to n of x */
 #define GET_BITS(x, m, n) ((((uint32)x) << (31 - (n))) >> ((31 - (n)) + (m)))
-/** True if v is a power of two (1, 2, 4, 8, ...)
+/** True if v is a power of two (1, 2, 4, 8, ...) */
 #define IS_POWER_OF_TWO(v)  ((v) && !((v) & ((v) - 1)))
 
 /*


### PR DESCRIPTION
This is a prototype that lets you set the USART RX buffer size at initilisation time.  It adds a usart_init_ex() which takes the buffer size in bytes.  The contentious thing is that it adds an allocate only heap.

As a side effect, the RAM usage is reduced as struct usart_dev becomes const and unused ports don't leave an unused buffer hanging around.

Let me know what you think and if it's good then I'll figure out the heap/Newlib malloc interaction.
