### PR TITLE
Add __assert_func() and abort() implementations.

### DIFF
--- a/libmaple/util.c
+++ b/libmaple/util.c
@@ -81,6 +81,16 @@ void __error(void) {
 }
 
 /**
+ * @brief Enable the error USART for writing.
+ * @sideeffect Configures ERROR_USART appropriately for writing.
+ */
+void _enable_error_usart() {
+    gpio_set_mode(ERROR_TX_PORT, ERROR_TX_PIN, GPIO_AF_OUTPUT_PP);
+    usart_init(ERROR_USART);
+    usart_set_baud_rate(ERROR_USART, ERROR_USART_CLK_SPEED, ERROR_USART_BAUD);
+}
+
+/**
  * @brief Print an error message on a UART upon a failed assertion
  *        and throb the error LED, if there is one defined.
  * @param file Source file of failed assertion
@@ -90,9 +100,7 @@ void __error(void) {
  */
 void _fail(const char* file, int line, const char* exp) {
     /* Initialize the error USART */
-    gpio_set_mode(ERROR_TX_PORT, ERROR_TX_PIN, GPIO_AF_OUTPUT_PP);
-    usart_init(ERROR_USART);
-    usart_set_baud_rate(ERROR_USART, ERROR_USART_CLK_SPEED, ERROR_USART_BAUD);
+    _enable_error_usart();
 
     /* Print failed assert message */
     usart_putstr(ERROR_USART, "ERROR: FAILED ASSERT(");
@@ -104,17 +112,32 @@ void _fail(const char* file, int line, const char* exp) {
     usart_putc(ERROR_USART, '\n');
     usart_putc(ERROR_USART, '\r');
 
-    /* Error fade */
+    /* Shutdown and error fade */
     __error();
 }
 
 /**
  * @brief Provide an __assert_func handler to libc so that calls to assert() get
- * redirected to _fail.
+ *        redirected to _fail.
  */
 void __assert_func(const char* file, int line, const char* method,
                    const char* expression) {
     _fail(file, line, expression);
+}
+
+/**
+ * @brief Provide an abort() implementation that aborts execution and enters an
+ *        error state with the throbbing LED indicator.
+ */
+void abort() {
+    /* Initialize the error USART */
+    _enable_error_usart();
+
+    /* Print abort message. */
+    usart_putstr(ERROR_USART, "ERROR: PROGRAM ABORTED VIA abort()\n\r");
+
+    /* Shutdown and error fade */
+    __error();
 }
 
 /**


### PR DESCRIPTION
Adding __assert_func() allows the user of assert() from assert.h and adding an abort() implementation allows the use of STL primitives that call abort() in error cases.
