### PR TITLE
Weaken _read and _write syscalls. 

### DIFF
--- a/libmaple/syscalls.c
+++ b/libmaple/syscalls.c
@@ -101,7 +101,7 @@ unsigned char getch(void) {
     return 0;
 }
 
-
+__attribute__ ((weak))
 int _read(int fd, char *buf, size_t cnt) {
     *buf = getch();
 
@@ -151,6 +151,7 @@ void cgets(char *s, int bufsize) {
     return;
 }
 
+__attribute__ ((weak))
 int _write(int fd, const char *buf, size_t cnt) {
     int i;
 


### PR DESCRIPTION
This makes it easy to implement an 
application-specific printf/scanf by overriding those syscalls with
versions which interact with the USART of your choice.

Signed-off-by: maniacbug maniacbug@ymail.com
