### PR TITLE
Workaround (for reference): Avoid race lock up in usart

### DIFF
--- a/libmaple/usart.c
+++ b/libmaple/usart.c
@@ -102,6 +102,11 @@ void usart_init(usart_dev *dev) {
     rb_init(dev->rb, USART_RX_BUF_SIZE, dev->rx_buf);
     rcc_clk_enable(dev->clk_id);
     nvic_irq_enable(dev->irq_num);
+
+    /* Set to max priority to avoid race condition where register presumably
+     * might change before it can be picked out by USART interrupt and cause
+     * it to lock up. */
+    nvic_irq_set_priority (dev->irq_num, 0);
 }
 
 /**

--- a/libmaple/usart.h
+++ b/libmaple/usart.h
@@ -309,7 +309,9 @@ static inline void usart_putstr(usart_dev *dev, const char* str) {
  * @see usart_data_available()
  */
 static inline uint8 usart_getc(usart_dev *dev) {
-    return rb_remove(dev->rb);
+    /* Use rb_safe_remove to avoid race in case another interrupt have reset
+     * or cleared the ringbuffer */
+    return rb_safe_remove (dev->rb);
 }
 
 /**


### PR DESCRIPTION
Workaround, submitted for reference: Long external interrupts may cause usart reads to lock up if they
prevent usart interrupts to be handled quick enough. This patch
increases usart interrupt priority and prevents the usart interrupt from
being delayed.

Signed-off-by: Gaute Hope eg@gaute.vetsj.com
