### PR TITLE
Call python2 specifically to make the reset script work out of the box o...

### DIFF
--- a/support/scripts/reset.py
+++ b/support/scripts/reset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import serial
 import os


### PR DESCRIPTION
...n systems where "/usr/bin/env python" links to python3 by default (e.g. ArchLinux), This is in accordance with "http://www.python.org/dev/peps/pep-0394/"
