### PR TITLE
Make the reset script work for both python2 and python3

### DIFF
--- a/support/scripts/reset.py
+++ b/support/scripts/reset.py
@@ -37,12 +37,12 @@ def choose_path(possible_paths):
     elif len(possible_paths) == 1:
         return possible_paths[0]
     else:
-        print 'Found multiple candidates for the Maple device:'
+        print ('Found multiple candidates for the Maple device:')
         return choose_among_options(possible_paths)
 
 def choose_among_options(options):
     for (i,p) in enumerate(options):
-        print '\t%d. %s' % (i+1, p)
+        print ('\t%d. %s' % (i+1, p))
 
     prompt = 'Enter a number to select one, or q to quit: '
     while True:
@@ -63,12 +63,12 @@ plat_sys = platform.system()
 plat_bits = platform.architecture()[0]
 if plat_sys == 'Linux':
     if plat_bits == '64bit':
-        print 'You appear to be using 64-bit Linux. Let us know if this works.'
+        print ('You appear to be using 64-bit Linux. Let us know if this works.')
     maple_path = unix_get_maple_path('ttyACM')
     # fall back on /dev/maple if that doesn't work
     if maple_path is None:
         maple_path = '/dev/maple'
-        print 'Could not find Maple serial port; defaulting to /dev/maple.'
+        print ('Could not find Maple serial port; defaulting to /dev/maple.')
 elif plat_sys == 'Darwin':
     maple_path = unix_get_maple_path('tty.usbmodem')
 elif plat_sys == 'Windows':
@@ -78,17 +78,17 @@ else:
                            "the path to the Maple's serial port device file:")
 
 if maple_path is None:
-    print 'Could not find the Maple serial port for reset.', \
+    print ('Could not find the Maple serial port for reset.', \
         'Perhaps this is your first upload, or the board is already', \
-        'in bootloader mode.'
-    print
-    print "If your sketch doesn't upload, try putting your Maple", \
+        'in bootloader mode.')
+    print ()
+    print ("If your sketch doesn't upload, try putting your Maple", \
         'into bootloader mode manually by pressing the RESET button', \
         'then letting it go and quickly pressing button BUT', \
-        '(hold for several seconds).'
+        '(hold for several seconds).')
     sys.exit()
 
-print 'Using %s as Maple serial port' % maple_path
+print ('Using %s as Maple serial port' % maple_path)
 
 try:
     ser = serial.Serial(maple_path, baudrate=115200, xonxoff=1)
@@ -110,7 +110,7 @@ try:
         time.sleep(0.01)
         ser.setDTR(0)
         time.sleep(0.01)
-        ser.write("1EAF")
+        ser.write("1EAF".encode("ascii"))
 
         # Windows quirk: delay a bit before proceeding
         if plat_sys == 'Windows': time.sleep(0.5)
@@ -119,6 +119,6 @@ try:
         ser.close()
 
 except Exception as e:
-    print 'Failed to open serial port %s for reset' % maple_path
+    print ('Failed to open serial port %s for reset' % maple_path)
     sys.exit()
 


### PR DESCRIPTION
Make the reset script work for both python2 and python3 by putting brackets around print statements and properly encoding the string sent with ser.write

Signed-off-by: Hanspeter Portner agenthp@users.sf.net
