### PR TITLE
Changes in the SPI write function to wait for an empty TXR-Flag

### DIFF
--- a/libmaple/spi.c
+++ b/libmaple/spi.c
@@ -94,7 +94,9 @@ void spi_slave_enable(spi_dev *dev, spi_mode mode, uint32 flags) {
 uint32 spi_tx(spi_dev *dev, const void *buf, uint32 len) {
     uint32 txed = 0;
     uint8 byte_frame = spi_dff(dev) == SPI_DFF_8_BIT;
-    while (spi_is_tx_empty(dev) && (txed < len)) {
+    while (txed < len) {
+        while(!spi_is_tx_empty(dev))
+            ;
         if (byte_frame) {
             dev->regs->DR = ((const uint8*)buf)[txed++];
         } else {

--- a/wirish/HardwareSPI.cpp
+++ b/wirish/HardwareSPI.cpp
@@ -173,9 +173,8 @@ void HardwareSPI::write(uint8 byte) {
 
 void HardwareSPI::write(const uint8 *data, uint32 length) {
     uint32 txed = 0;
-    while (txed < length) {
-        txed += spi_tx(this->spi_d, data + txed, length - txed);
-    }
+    spi_tx(this->spi_d, data + txed, length - txed);
+    spi_rx_reg(this->spi_d);
 }
 
 uint8 HardwareSPI::transfer(uint8 byte) {


### PR DESCRIPTION
Changed the write function to wait for an empty transmit (TXE) Flag (as
described in manual on p 684). Now the HardwareSPI can use this function
without the workaround. BUT it has to read the RX-Buffer after the
transmit (if we are in full-duplex-mode) because the Slave "sends"
0xFF. If we don't read it the receive buffer will uphold the arbitrary
data and will return it (0xFF) on an attempt to read it

Signed-off-by: Marcus Putz marcus.putz@gmail.com
