### PR TITLE
stm32f1/rules.mk: update include path for assembler files

### DIFF
--- a/libmaple/stm32f1/performance/isrs.S
+++ b/libmaple/stm32f1/performance/isrs.S
@@ -26,6 +26,8 @@
 
 /* STM32F1 performance line ISR weak declarations */
 
+#include <libmaple/stm32.h>
+
 	.thumb
 
 /* Default handler for all non-overridden interrupts and exceptions */

--- a/libmaple/stm32f1/performance/vector_table.S
+++ b/libmaple/stm32f1/performance/vector_table.S
@@ -26,6 +26,8 @@
 
 /* STM32F1 performance line vector table */
 
+#include <libmaple/stm32.h>
+
 	.section	".stm32.interrupt_vector"
 
 	.globl	__stm32_vector_table

--- a/libmaple/stm32f1/rules.mk
+++ b/libmaple/stm32f1/rules.mk
@@ -6,6 +6,7 @@ BUILDDIRS       += $(BUILD_PATH)/$(d)
 
 # Local flags
 CFLAGS_$(d) = -I$(d) $(LIBMAPLE_PRIVATE_INCLUDES) $(LIBMAPLE_INCLUDES) -Wall -Werror
+ASFLAGS_$(d) = -I$(d) $(LIBMAPLE_PRIVATE_INCLUDES) $(LIBMAPLE_INCLUDES) -Wall -Werror
 
 # Extra BUILDDIRS
 BUILDDIRS += $(BUILD_PATH)/$(d)/$(MCU_F1_LINE)
@@ -33,7 +34,7 @@ OBJS_$(d) := $(sFILES_$(d):%.S=$(BUILD_PATH)/%.o) \
              $(cFILES_$(d):%.c=$(BUILD_PATH)/%.o)
 DEPS_$(d) := $(OBJS_$(d):%.o=%.d)
 
-$(OBJS_$(d)): TGT_ASFLAGS :=
+$(OBJS_$(d)): TGT_ASFLAGS := $(ASFLAGS_$(d))
 $(OBJS_$(d)): TGT_CFLAGS := $(CFLAGS_$(d))
 
 TGT_BIN += $(OBJS_$(d))


### PR DESCRIPTION
stm32f1/performance: load stm32.h in order to have STM32_HIGH_DENSITY when necessary

STM32_HIGH_DENSITY was not defined in isrs.S and vector_table.S for a high density STM32. This was because stm32.h where the flag is now defined (in contrast to being defined on the command line in an earlier version of libmaple) was not included. This led to crashes when using one of the high density peripherals.

Updated the ASFLAGS to have the correct include path in rules.mk.
Include stm32.h in the assembler files.
