### PR TITLE
usb_cdcacm.c: reenable the endpoint if an empty bulk transfer was received.

### DIFF
--- a/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -535,6 +535,13 @@ static void vcomDataRxCb(void) {
     usb_copy_from_pma((uint8*)vcomBufferRx, n_unread_bytes,
                       USB_CDCACM_RX_ADDR);
 
+
+    if (n_unread_bytes == 0) {
+        usb_set_ep_rx_count(USB_CDCACM_RX_ENDP, USB_CDCACM_RX_EPSIZE);
+        usb_set_ep_rx_stat(USB_CDCACM_RX_ENDP, USB_EP_STAT_RX_VALID);
+        rx_offset = 0;
+    }
+
     if (rx_hook) {
         rx_hook(USB_CDCACM_HOOK_RX, 0);
     }


### PR DESCRIPTION
usb_cdcacm.c: reenable the endpoint if an empty bulk transfer was received.

It is possible to receive empty bulk transfers. This would lead to the endpoint never being reenabled as this was handled by the read routine. This caused the USB to hang.

Signed-off-by: Manuel Odendahl wesen@ruinwesen.com
