### PR TITLE
Add fix to support Summon/Linaro GCC ARM embedded toolchain.

### DIFF
--- a/support/make/build-rules.mk
+++ b/support/make/build-rules.mk
@@ -39,6 +39,10 @@ ifneq ($(findstring ARM/embedded,$(shell $(CC) --version)),)
 # GCC ARM Embedded, https://launchpad.net/gcc-arm-embedded/
 LD_TOOLCHAIN_PATH := $(LDDIR)/toolchains/gcc-arm-embedded
 endif
+ifneq ($(findstring Linaro GCC,$(shell $(CC) --version)),)
+# Summon/Linaro GCC ARM Embedded, https://github.com/esden/summon-arm-toolchain
+LD_TOOLCHAIN_PATH := $(LDDIR)/toolchains/gcc-arm-embedded
+endif
 # Add toolchain directory to LD search path
 TOOLCHAIN_LDFLAGS := -L $(LD_TOOLCHAIN_PATH)
 


### PR DESCRIPTION
Hi, would you please to review and merge it? Without this fix it produces unresolved _exit reference on ld stage due to omitted nosys library. It happens because summon/linaro gcc reports a different signature on 'gcc --version'. So gcc still unrecognized by build system. Tested with:

arm-none-eabi-gcc (Linaro GCC 4.6-2011.10) 4.6.2 20111004 (prerelease)
Copyright (C) 2011 Free Software Foundation, Inc.

Thank you,
Dmitry
