### PR TITLE
Added I2C_MSG_WRITE definition

### DIFF
--- a/libmaple/include/libmaple/i2c.h
+++ b/libmaple/include/libmaple/i2c.h
@@ -91,6 +91,7 @@ typedef struct i2c_reg_map {
 typedef struct i2c_msg {
     uint16 addr;                /**< Address */
 
+#define I2C_MSG_WRITE           0x0
 #define I2C_MSG_READ            0x1
 #define I2C_MSG_10BIT_ADDR      0x2
     /**


### PR DESCRIPTION
Hi, would you pls to review and merge it?

I2C_MSG_WRITE definition has been added to avoid hacks like:
msgs[0].flags = 0; // write

Thank you,
Signed-off-by: Dmitry Prokhorov dipspb@gmail.com
