### PR TITLE
add switch to support disabling USBSerial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ include $(MAKEDIR)/build-templates.mk
 TARGET_FLAGS    += -I$(LIBMAPLE_PATH)/include/libmaple                       \
                    -I$(WIRISH_PATH)/include/wirish
 TARGET_FLAGS += -I$(LIBRARIES_PATH) # for internal lib. includes, e.g. <Wire/WireBase.h>
-GLOBAL_CFLAGS   := -Os -g3 -gdwarf-2 -nostdlib \
+GLOBAL_CFLAGS   := $(GLOBAL_CFLAGS) \
+                   -Os -g3 -gdwarf-2 -nostdlib \
                    -ffunction-sections -fdata-sections \
 		   -Wl,--gc-sections $(TARGET_FLAGS)
 GLOBAL_CXXFLAGS := -fno-rtti -fno-exceptions -Wall $(TARGET_FLAGS)

--- a/libmaple/usb/stm32f1/usb_cdcacm.c
+++ b/libmaple/usb/stm32f1/usb_cdcacm.c
@@ -24,6 +24,8 @@
  * SOFTWARE.
  *****************************************************************************/
 
+#ifndef DISABLE_SERIALUSB
+
 /**
  * @file libmaple/usb/stm32f1/usb_cdcacm.c
  * @brief USB CDC ACM (a.k.a. virtual serial terminal, VCOM).
@@ -718,3 +720,5 @@ static void usbSetConfiguration(void) {
 static void usbSetDeviceAddress(void) {
     USBLIB->state = USB_ADDRESSED;
 }
+
+#endif

--- a/wirish/include/wirish/boards.h
+++ b/wirish/include/wirish/boards.h
@@ -168,6 +168,7 @@ bool boardUsesPin(uint8 pin);
  * @brief Feature test: nonzero iff the board has SerialUSB.
  */
 #define BOARD_HAVE_SERIALUSB (defined(BOARD_USB_DISC_DEV) && \
-                              defined(BOARD_USB_DISC_BIT))
+                              defined(BOARD_USB_DISC_BIT) && \
+                              !defined(DISABLE_SERIALUSB))
 
 #endif


### PR DESCRIPTION
Added switch ("DISABLE_SERIALUSB") to allow a user to disable the USBSerial port completely.

I've successfully implemented a [usbMassStorage](https://github.com/joeferner/maple-usbMassStorage) device driver by porting the STMicro code for the maple but to work with the Maple USB library I needed to use User_Standard_Requests, Device_Property, and Device_Table global variables. In order to do this I need to disable the existing cdcacm driver.
