### PR TITLE
Fix BKP write enable

### DIFF
--- a/libmaple/stm32f1/bkp.c
+++ b/libmaple/stm32f1/bkp.c
@@ -62,14 +62,14 @@ void bkp_init(void) {
  * @see bkp_init()
  */
 void bkp_enable_writes(void) {
-    *bb_perip(&PWR_BASE->CR, PWR_CR_DBP) = 1;
+    *bb_perip(&PWR_BASE->CR, PWR_CR_DBP_BIT) = 1;
 }
 
 /**
  * Disable write access to the backup registers.
  */
 void bkp_disable_writes(void) {
-    *bb_perip(&PWR_BASE->CR, PWR_CR_DBP) = 0;
+    *bb_perip(&PWR_BASE->CR, PWR_CR_DBP_BIT) = 0;
 }
 
 /**


### PR DESCRIPTION
The BKP enable function was broken, we need to use the BIT number to initialize the register, not the full bit mask.
