### PR TITLE
Updating the I2C lib to support write nomenclature

### DIFF
--- a/examples/i2c-mcp4725-dac.cpp
+++ b/examples/i2c-mcp4725-dac.cpp
@@ -42,7 +42,7 @@ static i2c_msg read_msg;
 
 void mcp_i2c_setup(void) {
     write_msg.addr = MCP_ADDR;
-    write_msg.flags = 0; // write, 7 bit address
+    write_msg.flags = I2C_MSG_WRITE; // write, 7 bit address
     write_msg.length = sizeof(write_msg_data);
     write_msg.xferred = 0;
     write_msg.data = write_msg_data;

--- a/libmaple/include/libmaple/i2c.h
+++ b/libmaple/include/libmaple/i2c.h
@@ -91,6 +91,7 @@ typedef struct i2c_reg_map {
 typedef struct i2c_msg {
     uint16 addr;                /**< Address */
 
+#define I2C_MSG_WRITE           0x0
 #define I2C_MSG_READ            0x1
 #define I2C_MSG_10BIT_ADDR      0x2
     /**


### PR DESCRIPTION
Just want to be externally consistent in the use of the r/w flags. Also updated the I2C example which shipped from Leaf.
