### PR TITLE
Preserve previous usb state when suspending / restore on resume

### DIFF
--- a/libmaple/include/libmaple/usb.h
+++ b/libmaple/include/libmaple/usb.h
@@ -151,6 +151,7 @@ typedef struct usblib_dev {
     void (**ep_int_in)(void);
     void (**ep_int_out)(void);
     usb_dev_state state;
+    usb_dev_state prevState;
     rcc_clk_id clk_id;
 } usblib_dev;
 


### PR DESCRIPTION
A suspended device would not recover correctly after a USB suspend/resume event. The USB code from STM didn't track the previous state and would leave the device USB_SUSPENDED. I haven't gone too far into how the suspend works, but this should do it for both INTERNAL and EXTERNAL resumes.
