### PR TITLE
always clear ISR DMA bit before even calling handler

### DIFF
--- a/libmaple/dma_private.h
+++ b/libmaple/dma_private.h
@@ -38,10 +38,10 @@
  * in the series support files, which need dma_irq_handler().) */
 #ifdef DMA_GET_HANDLER
 static __always_inline void dma_irq_handler(dma_dev *dev, dma_tube tube) {
+    dma_clear_isr_bits(dev, tube); /* in case handler doesn't */
     void (*handler)(void) = DMA_GET_HANDLER(dev, tube);
     if (handler) {
         handler();
-        dma_clear_isr_bits(dev, tube); /* in case handler doesn't */
     }
 }
 #endif


### PR DESCRIPTION
So I am a bit unsure about this one. I had this troublesome effect:
1. i was running code with -O0 for a long time (mistake on my part)
2. i switched to -Os -> this led to flakiness in the SPI transfer to the display (flaky timing)
3. i tried to hunt down the exact timing, but couldn't. Basically, if dma.c was compiled with -O2, it worked, with -Os, it didn't
4. i tried some random delay sprinkling, didn't help. 

I then realized that I triggered a new DMA transfer inside the IRQ routine, but didn't clear the ISR flag first. I am now wondering why the IRQ handler dispatcher shouldn't always clear it as the first thing, to get acknowledging the IRQ out of the way.

I am maybe missing something?
