### PR TITLE
Add support for mini STM32F103C8T6 board.

### DIFF
--- a/support/ld/stm32/mem/sram_20k_flash_64k/mem-flash.inc
+++ b/support/ld/stm32/mem/sram_20k_flash_64k/mem-flash.inc
@@ -1,0 +1,5 @@
+MEMORY
+{
+  ram (rwx) : ORIGIN = 0x20000C00, LENGTH = 17K
+  rom (rx)  : ORIGIN = 0x08005000, LENGTH = 44K
+}

--- a/support/ld/stm32/mem/sram_20k_flash_64k/mem-jtag.inc
+++ b/support/ld/stm32/mem/sram_20k_flash_64k/mem-jtag.inc
@@ -1,0 +1,5 @@
+MEMORY
+{
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
+  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 64K
+}

--- a/support/ld/stm32/mem/sram_20k_flash_64k/mem-ram.inc
+++ b/support/ld/stm32/mem/sram_20k_flash_64k/mem-ram.inc
@@ -1,0 +1,5 @@
+MEMORY
+{
+  ram (rwx) : ORIGIN = 0x20000C00, LENGTH = 17K
+  rom (rx)  : ORIGIN = 0x08005000, LENGTH = 0K
+}

--- a/support/make/board-includes/mini_stm32.mk
+++ b/support/make/board-includes/mini_stm32.mk
@@ -1,0 +1,7 @@
+MCU := STM32F103C8
+PRODUCT_ID := 0003
+ERROR_LED_PORT := GPIOB
+ERROR_LED_PIN  := 2
+MCU_SERIES := stm32f1
+MCU_F1_LINE := performance
+LD_MEM_DIR := sram_20k_flash_64k

--- a/wirish/boards/mini_stm32/board.cpp
+++ b/wirish/boards/mini_stm32/board.cpp
@@ -1,0 +1,140 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2011 LeafLabs, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+/**
+ * @file   wirish/boards/mini_stm32/board.cpp
+ * @author Daniel Serpell <daniel.serpell@gmail.com>
+ * @brief  Board file for mini STM32F103C8T6 board from www.lctech-inc.com.
+ *
+ * Board is available from:
+ * http://www.lctech-inc.com/Hardware/Detail.aspx?id=0172e854-77b0-43d5-b300-68e570c914fd
+ *
+ * Based on maple-mini configuration.
+ */
+
+#include <board/board.h>
+
+#include <libmaple/gpio.h>
+#include <libmaple/timer.h>
+
+#include <wirish/wirish_debug.h>
+#include <wirish/wirish_types.h>
+
+/* Only enable SWD debugging to maximize utilizable pins. */
+void boardInit(void) {
+    afio_cfg_debug_ports(AFIO_DEBUG_SW_ONLY);
+}
+
+extern const stm32_pin_info PIN_MAP[BOARD_NR_GPIO_PINS] = {
+
+    /* P8 */
+
+    /* 1  3.3V */
+    /* 2  VddA */
+    {GPIOA, TIMER2, ADC1,  0, 1,    0}, /*  3  PA0    D0 */
+    {GPIOA, TIMER2, ADC1,  1, 2,    1}, /*  4  PA1    D1 */
+    {GPIOA, TIMER2, ADC1,  2, 3,    2}, /*  5  PA2    D2 */
+    {GPIOA, TIMER2, ADC1,  3, 4,    3}, /*  6  PA3    D3 */
+    {GPIOA,   NULL, ADC1,  4, 0,    4}, /*  7  PA4    D4 */
+    {GPIOA,   NULL, ADC1,  5, 0,    5}, /*  8  PA5    D5 */
+    {GPIOA, TIMER3, ADC1,  6, 1,    6}, /*  9  PA6    D6 */
+    {GPIOA, TIMER3, ADC1,  7, 2,    7}, /* 10  PA7    D7 */
+    {GPIOB, TIMER3, ADC1,  0, 3,    8}, /* 11  PB0    D8 */
+    {GPIOB, TIMER3, ADC1,  1, 4,    9}, /* 12  PB1    D9 */
+    {GPIOB,   NULL, NULL,  2, 0, ADCx}, /* 13  PB2   D10 */
+    {GPIOB,   NULL, NULL, 10, 0, ADCx}, /* 14  PB10  D11 */
+    {GPIOB,   NULL, NULL, 12, 0, ADCx}, /* 15  PB12  D12 */
+    {GPIOB,   NULL, NULL, 11, 0, ADCx}, /* 16  PB11  D13 */
+    {GPIOB,   NULL, NULL, 14, 0, ADCx}, /* 17  PB14  D14 */
+    {GPIOB,   NULL, NULL, 13, 0, ADCx}, /* 18  PB13  D15 */
+    {GPIOA, TIMER1, NULL,  8, 1, ADCx}, /* 19  PA8   D16 */
+    {GPIOB,   NULL, NULL, 15, 0, ADCx}, /* 20  PB15  D17 */
+    {GPIOA, TIMER1, NULL, 10, 3, ADCx}, /* 21  PA10  D18 */
+    {GPIOA, TIMER1, NULL,  9, 2, ADCx}, /* 22  PA9   D19 */
+    /* 23  GND */
+    /* 24  GND */
+
+    /* P9 */
+
+    /* 1  3.3V */
+    /* 2  3.3V */
+    /* 3  NRST */
+    /* 4  OSC_OUT */
+    /* 5  OSC_IN  */
+    {GPIOC,   NULL, NULL, 15, 0, ADCx}, /*  6  PC15  D20 */
+    {GPIOC,   NULL, NULL, 14, 0, ADCx}, /*  7  PC14  D21 */
+    {GPIOC,   NULL, NULL, 13, 0, ADCx}, /*  8  PC13  D22 */
+    /* 9  VBat */
+    {GPIOB, TIMER4, NULL,  9, 4, ADCx}, /* 10  PB9   D23 */
+    {GPIOB, TIMER4, NULL,  8, 3, ADCx}, /* 11  PB8   D24 */
+    /* 12  BOOT0 */
+    {GPIOB, TIMER4, NULL,  7, 2, ADCx}, /* 13  PB7   D25 */
+    {GPIOB, TIMER4, NULL,  6, 1, ADCx}, /* 14  PB6   D26 */
+    {GPIOB,   NULL, NULL,  5, 0, ADCx}, /* 15  PB5   D27 */
+    {GPIOB,   NULL, NULL,  4, 0, ADCx}, /* 16  PB4   D28  JNTRST */
+    {GPIOB,   NULL, NULL,  3, 0, ADCx}, /* 17  PB3   D29  JTDO */
+    {GPIOA,   NULL, NULL, 15, 0, ADCx}, /* 18  PA15  D30  JTDI */
+    {GPIOA,   NULL, NULL, 14, 0, ADCx}, /* 19  PA14  D31 SWCLK */
+    {GPIOA,   NULL, NULL, 13, 0, ADCx}, /* 20  PA13  D32 SWDIO */
+    {GPIOA,   NULL, NULL, 12, 0, ADCx}, /* 21  PA12  D33  USB+ */
+    {GPIOA, TIMER1, NULL, 11, 4, ADCx}  /* 22  PA11  D34  USB- */
+    /* 23  GND */
+    /* 24  GND */
+
+    /* UART CONNECTOR */
+    /* 1  5V IN/OUT */
+    //{GPIOA, TIMER1, NULL,  9, 2, ADCx}, /*  2/PA9   TX */
+    //{GPIOA, TIMER1, NULL, 10, 3, ADCx}, /*  3/PA10  RX */
+    /* 4  GND */
+
+    /* JTAG CONNECTOR */
+    /* 1  3.3V OUT */
+    //{GPIOB,   NULL, NULL,  4, 0, ADCx}, /*  3/PB4  */
+    //{GPIOA,   NULL, NULL, 15, 0, ADCx}, /*  5/PA15 */
+    //{GPIOA,   NULL, NULL, 13, 0, ADCx}, /*  7/PA13 */
+    //{GPIOA,   NULL, NULL, 14, 0, ADCx}, /*  9/PA14 */
+    /* 11 ?? */
+    //{GPIOB,   NULL, NULL,  3, 0, ADCx}, /* 13/PB3  */
+
+};
+
+extern const uint8 boardPWMPins[BOARD_NR_PWM_PINS] __FLASH__ = {
+    0, 1, 2, 3, 6, 7, 8, 9, 16, 18, 19, 23, 24, 25, 26, 34
+};
+
+extern const uint8 boardADCPins[BOARD_NR_ADC_PINS] __FLASH__ = {
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+};
+
+#define USB_DP 33
+#define USB_DM 34
+
+#define OSC32_IN  21
+#define OSC32_OUT 20
+
+extern const uint8 boardUsedPins[BOARD_NR_USED_PINS] __FLASH__ = {
+    OSC32_IN, OSC32_OUT, USB_DP, USB_DM
+};

--- a/wirish/boards/mini_stm32/include/board/board.h
+++ b/wirish/boards/mini_stm32/include/board/board.h
@@ -1,0 +1,87 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2011 LeafLabs, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+/**
+ * @file   wirish/boards/mini_stm32/include/board/board.h
+ * @author Daniel Serpell <daniel.serpell@gmail.com>
+ * @brief  Board header for mini STM32F103C8T6 board from www.lctech-inc.com.
+ *
+ * Board is available from:
+ * http://www.lctech-inc.com/Hardware/Detail.aspx?id=0172e854-77b0-43d5-b300-68e570c914fd
+ *
+ * Based on maple-mini configuration.
+ */
+
+#ifndef _BOARD_MINI_STM32_H_
+#define _BOARD_MINI_STM32_H_
+
+#define CYCLES_PER_MICROSECOND    72
+#define SYSTICK_RELOAD_VAL     71999 /* takes a cycle to reload */
+
+// The board does not have buttons or LEDs, the following are suggested locations.
+#define BOARD_BUTTON_PIN          27
+#define BOARD_LED_PIN             28
+
+#define BOARD_NR_USARTS           3
+#define BOARD_USART1_TX_PIN       19
+#define BOARD_USART1_RX_PIN       18
+#define BOARD_USART2_TX_PIN       2
+#define BOARD_USART2_RX_PIN       3
+#define BOARD_USART3_TX_PIN       11
+#define BOARD_USART3_RX_PIN       13
+
+#define BOARD_NR_SPI              2
+#define BOARD_SPI1_NSS_PIN        4
+#define BOARD_SPI1_MOSI_PIN       7
+#define BOARD_SPI1_MISO_PIN       6
+#define BOARD_SPI1_SCK_PIN        5
+#define BOARD_SPI2_NSS_PIN        12
+#define BOARD_SPI2_MOSI_PIN       17
+#define BOARD_SPI2_MISO_PIN       14
+#define BOARD_SPI2_SCK_PIN        15
+
+#define BOARD_NR_GPIO_PINS        35
+#define BOARD_NR_PWM_PINS         16
+#define BOARD_NR_ADC_PINS         10
+#define BOARD_NR_USED_PINS         4
+
+#define BOARD_JTMS_SWDIO_PIN      32
+#define BOARD_JTCK_SWCLK_PIN      31
+#define BOARD_JTDI_PIN            30
+#define BOARD_JTDO_PIN            29
+#define BOARD_NJTRST_PIN          28
+
+// The board has no USB DISK pin, only a jumper, so we use a non existent GPIO.
+#define BOARD_USB_DISC_DEV        GPIOC
+#define BOARD_USB_DISC_BIT        0
+
+enum {
+    PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7, PB0, PB1, PB2, PB10, PB12, PB11, PB14,
+    PB13, PA8, PB15, PA10, PA9, PC15, PC14, PC13, PB9, PB8, PB7, PB6, PB5, PB4, PB3,
+    PA15, PA14, PA13, PA12, PA11
+};
+
+#endif


### PR DESCRIPTION
The board is a header type board with 8MHz and 32kHz crystals, mini USB
connector and headers for accessing all the pins. There is only power
LED and reset button.

Signed-off-by: Daniel Serpell daniel.serpell@gmail.com
