### PR TITLE
Alternative rules file

### DIFF
--- a/support/scripts/ 45-maple.rules.alt
+++ b/support/scripts/ 45-maple.rules.alt
@@ -1,0 +1,3 @@
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1eaf", ATTRS{idProduct}=="0003", RUN+="/sbin/modprobe cdc-acm", GROUP="plugdev", MODE="0660", SYMLINK+="maple"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1eaf", ATTRS{idProduct}=="0004", RUN+="/sbin/modprobe cdc-acm", GROUP="plugdev", MODE="0660", SYMLINK+="maple"
+ATTRS{idVendor}=="1eaf",  ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
Linux does not link the proper device if the cdc-acm module is not loaded.
