### PR TITLE
Revert "always clear ISR DMA bit before even calling handler"

### DIFF
--- a/libmaple/dma_private.h
+++ b/libmaple/dma_private.h
@@ -38,10 +38,10 @@
  * in the series support files, which need dma_irq_handler().) */
 #ifdef DMA_GET_HANDLER
 static __always_inline void dma_irq_handler(dma_dev *dev, dma_tube tube) {
-    dma_clear_isr_bits(dev, tube); /* in case handler doesn't */
     void (*handler)(void) = DMA_GET_HANDLER(dev, tube);
     if (handler) {
         handler();
+        dma_clear_isr_bits(dev, tube); /* in case handler doesn't */
     }
 }
 #endif


### PR DESCRIPTION
This change breaks the possibility to e.g. dma_get_irq_cause() and thus the possibility to e.g. detect errors / half complete in the transfer. To start a new dma from the irq, the behaviour may be mimicked by calling dma_clear_isr_bits() in the handler.
