### PR TITLE
Adding support for NUCLEO-F103RB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ LDFLAGS  = $(TARGET_LDFLAGS) $(TOOLCHAIN_LDFLAGS) -mcpu=cortex-m3 -mthumb \
            -Xassembler --march=armv7-m -Wall
 #          -Xlinker --print-gc-sections \
 
+# You can uncomment and customize this line to specify the clocks you are using
+# GLOBAL_CFLAGS  += -DSTM32_PCLK1=18000000 -DSTM32_PCLK2=36000000 -DSTM32_DELAY_US_MULT=6
+
 ##
 ## Set all submodules here
 ##
@@ -135,7 +138,7 @@ ifneq ($(PREV_BUILD_TYPE), $(MEMORY_TARGET))
 	$(shell rm -rf $(BUILD_PATH))
 endif
 
-sketch: build-check MSG_INFO $(BUILD_PATH)/$(BOARD).bin
+sketch: build-check MSG_INFO $(BUILD_PATH)/$(BOARD).bin $(BUILD_PATH)/$(BOARD).hex
 
 clean:
 	rm -rf build

--- a/build-targets.mk
+++ b/build-targets.mk
@@ -16,6 +16,9 @@ library: $(BUILD_PATH)/libmaple.a
 $(BUILD_PATH)/$(BOARD).elf: $(BUILDDIRS) $(TGT_BIN) $(OBJ_FILES)
 	$(SILENT_LD) $(CXX) $(LDFLAGS) -o $@ $(TGT_BIN) $(BUILD_PATH)/main.o -Wl,-Map,$(BUILD_PATH)/$(BOARD).map
 
+$(BUILD_PATH)/$(BOARD).hex: $(BUILD_PATH)/$(BOARD).elf
+	$(SILENT_OBJCOPY) $(OBJCOPY) -v -Oihex $(BUILD_PATH)/$(BOARD).elf $@ 1>/dev/null
+
 $(BUILD_PATH)/$(BOARD).bin: $(BUILD_PATH)/$(BOARD).elf
 	$(SILENT_OBJCOPY) $(OBJCOPY) -v -Obinary $(BUILD_PATH)/$(BOARD).elf $@ 1>/dev/null
 	$(SILENT_DISAS) $(DISAS) -d $(BUILD_PATH)/$(BOARD).elf > $(BUILD_PATH)/$(BOARD).disas

--- a/support/make/board-includes/nucleo.mk
+++ b/support/make/board-includes/nucleo.mk
@@ -1,0 +1,10 @@
+MCU := STM32F103RB
+PRODUCT_ID := 0003
+ERROR_LED_PORT := GPIOA
+ERROR_LED_PIN  := 5
+MCU_SERIES := stm32f1
+MCU_F1_LINE := performance
+# This crap is due to ld-script limitations. If you know of a better
+# way to go about this (like some magic ld switches to specify MEMORY
+# at the command line), please tell us!
+LD_MEM_DIR := sram_20k_flash_128k

--- a/wirish/boards/nucleo/board.cpp
+++ b/wirish/boards/nucleo/board.cpp
@@ -1,0 +1,149 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2011 LeafLabs, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+/**
+ * @file   wirish/boards/nucleo/board.cpp
+ * @author Grégoire Passault <g.passault@gmail.com>
+ * @brief  Nucleo board file
+ *
+ * This mapping was done using the NUCLEO documentation and may be incomplete
+ * or contains error
+ *
+ * If you want to use the PWM outputs, consider understanding all the remapping
+ * process that can be involved. You may have to tweak this file regarding your goals.
+ */
+
+#include <board/board.h>         // For this board's header file
+
+#include <wirish/wirish_types.h> // For stm32_pin_info and its contents
+                                 // (these go into PIN_MAP).
+
+#include "boards_private.h"      // For PMAP_ROW(), which makes
+                                 // PIN_MAP easier to read.
+
+// boardInit(): NUCLEO rely on some remapping
+void boardInit(void) {
+    afio_remap(AFIO_REMAP_TIM2_FULL);
+    afio_remap(AFIO_REMAP_TIM3_PARTIAL);
+}
+
+namespace wirish {
+namespace priv {
+static stm32f1_rcc_pll_data pll_data = {RCC_PLLMUL_9};
+rcc_clk w_board_pll_in_clk = RCC_CLK_HSI;
+rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
+}
+}
+
+// Pin map: this lets the basic I/O functions (digitalWrite(),
+// analogRead(), pwmWrite()) translate from pin numbers to STM32
+// peripherals.
+//
+// PMAP_ROW() lets us specify a row (really a struct stm32_pin_info)
+// in the pin map. Its arguments are:
+//
+// - GPIO device for the pin (GPIOA, etc.)
+// - GPIO bit for the pin (0 through 15)
+// - Timer device, or NULL if none
+// - Timer channel (1 to 4, for PWM), or 0 if none
+// - ADC device, or NULL if none
+// - ADC channel, or ADCx if none
+extern const stm32_pin_info PIN_MAP[BOARD_NR_GPIO_PINS] = {
+
+    /* Arduino-like header, right connectors */
+
+    PMAP_ROW(GPIOA,   3,   NULL,  0, ADC1,    3), /* D0/PA3 */
+    PMAP_ROW(GPIOA,   2,   NULL,  0, ADC1,    2), /* D1/PA2 */
+    PMAP_ROW(GPIOA,  10,   NULL,  0, NULL, ADCx), /* D2/PA10 */
+    PMAP_ROW(GPIOB,   3, TIMER2,  2, NULL, ADCx), /* D3/PB3     REMAPPED */
+    PMAP_ROW(GPIOB,   5,   NULL,  0, NULL, ADCx), /* D4/PB5 */
+    PMAP_ROW(GPIOB,   4, TIMER3,  1, NULL, ADCx), /* D5/PB4     REMAPPED */
+    PMAP_ROW(GPIOB,  10, TIMER2,  3, NULL, ADCx), /* D6/PB10    REMAPPED */
+    PMAP_ROW(GPIOA,   8,   NULL,  0, NULL, ADCx), /* D7/PA8 */
+
+    PMAP_ROW(GPIOA,   9,   NULL,  0, NULL, ADCx), /* D8/PA9  */
+    PMAP_ROW(GPIOC,   7,   NULL,  0, NULL, ADCx), /* D9/PC7  */
+    PMAP_ROW(GPIOB,   6, TIMER4,  1, NULL, ADCx), /* D10/PB6 */
+    PMAP_ROW(GPIOA,   7, TIMER3,  2, ADC1,    7), /* D11/PA7 */
+    PMAP_ROW(GPIOA,   6,   NULL,  0, ADC1,    6), /* D12/PA6 */
+    PMAP_ROW(GPIOA,   5,   NULL,  0, ADC1,    5), /* D13/PA5 LED*/
+    PMAP_ROW(GPIOB,   9,   NULL,  0, NULL, ADCx), /* D14/PB9 */
+    PMAP_ROW(GPIOB,   8,   NULL,  0, NULL, ADCx), /* D15/PB8 */
+    
+    /* Arduino-like header, left connectors */
+
+    PMAP_ROW(GPIOA,   0, TIMER2,  1, ADC1,    0), /* D16/A0/PA0 */
+    PMAP_ROW(GPIOA,   1, TIMER2,  2, ADC1,    1), /* D17/A1/PA1 */
+    PMAP_ROW(GPIOA,   4,   NULL,  0, ADC1,    4), /* D18/A2/PA4 */
+    PMAP_ROW(GPIOB,   0, TIMER3,  3, ADC1,    8), /* D19/A3/PB0 */
+    PMAP_ROW(GPIOC,   1,   NULL,  0, ADC1,   11), /* D20/A4/PC1 */
+    PMAP_ROW(GPIOC,   0,   NULL,  0, ADC1,   10), /* D21/A5/PC0 */
+
+    /* Other pins */
+
+    PMAP_ROW(GPIOB,   7,   NULL,  0, NULL, ADCx), /* D22/PB7 */
+    PMAP_ROW(GPIOC,   2,   NULL,  0, ADC1,   12), /* D23/PC2 */
+    PMAP_ROW(GPIOC,   3,   NULL,  0, ADC1,   13), /* D24/PC3 */
+    PMAP_ROW(GPIOC,   4,   NULL,  0, ADC1,   14), /* D25/PC4 */
+    PMAP_ROW(GPIOC,   5,   NULL,  0, ADC1,   15), /* D26/PC5 */
+
+    PMAP_ROW(GPIOC,  13,   NULL,  0, NULL, ADCx), /* D27/PC13 USER BLUE BUTTON */
+    PMAP_ROW(GPIOC,  14,   NULL,  0, NULL, ADCx), /* D28/PC14 */
+    PMAP_ROW(GPIOC,  15,   NULL,  0, NULL, ADCx), /* D29/PC15 */
+    PMAP_ROW(GPIOD,   2,   NULL,  0, NULL, ADCx), /* D30/PD2 */
+    PMAP_ROW(GPIOC,  10,   NULL,  0, NULL, ADCx), /* D31/PC10 */
+    PMAP_ROW(GPIOB,   1,   NULL,  0, ADC1,    9), /* D32/PB1 */
+    PMAP_ROW(GPIOB,  11,   NULL,  0, NULL, ADCx), /* D33/PB11 */
+    PMAP_ROW(GPIOB,  12,   NULL,  0, NULL, ADCx), /* D34/PB12 */
+    PMAP_ROW(GPIOB,  13,   NULL,  0, NULL, ADCx), /* D35/PB13 */
+    PMAP_ROW(GPIOB,  14,   NULL,  0, NULL, ADCx), /* D36/PB14 */
+    PMAP_ROW(GPIOB,  15,   NULL,  0, NULL, ADCx), /* D37/PB15 */
+    PMAP_ROW(GPIOC,   6,   NULL,  0, NULL, ADCx), /* D38/PC6 */
+    PMAP_ROW(GPIOC,   8,   NULL,  0, NULL, ADCx), /* D39/PC8 */
+    PMAP_ROW(GPIOC,   9,   NULL,  0, NULL, ADCx), /* D40/PC9 */
+
+    PMAP_ROW(GPIOA,  13,   NULL,  0, NULL, ADCx), /* D41/PA13 */
+    PMAP_ROW(GPIOA,  14,   NULL,  0, NULL, ADCx), /* D42/PA14 */
+    PMAP_ROW(GPIOA,  15,   NULL,  0, NULL, ADCx), /* D43/PA15 */
+};
+
+// Array of pins you can use for pwmWrite(). Keep it in Flash because
+// it doesn't change, and so we don't waste RAM.
+extern const uint8 boardPWMPins[] __FLASH__ = {
+    3, 5, 6, 10, 11, 16, 17, 19
+};
+
+// Array of pins you can use for analogRead().
+extern const uint8 boardADCPins[] __FLASH__ = {
+    16, 17, 18, 19, 20, 21
+};
+
+// Array of pins that the board uses for something special. Other than
+// the button and the LED, it's usually best to leave these pins alone
+// unless you know what you're doing.
+extern const uint8 boardUsedPins[] __FLASH__ = {
+    BOARD_LED_PIN, BOARD_BUTTON_PIN
+};

--- a/wirish/boards/nucleo/include/board/board.h
+++ b/wirish/boards/nucleo/include/board/board.h
@@ -1,0 +1,102 @@
+/******************************************************************************
+ * The MIT License
+ *
+ * Copyright (c) 2011 LeafLabs, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *****************************************************************************/
+
+/**
+ * @file   wirish/boards/maple/include/board/board.h
+ * @author Marti Bolivar <mbolivar@leaflabs.com>
+ * @brief  Maple board header.
+ */
+
+#ifndef _BOARD_MAPLE_H_
+#define _BOARD_MAPLE_H_
+
+/**
+ * If you solder an external oscillator, you may run the board at 72mhz,
+ * else, we keep it at 36mhz for simplicity and stability
+ */
+#define CYCLES_PER_MICROSECOND  36
+
+/* Pin number for the built-in button. */
+#define BOARD_BUTTON_PIN        27
+
+/* Pin number for the built-in LED. */
+#define BOARD_LED_PIN           13
+
+/* Number of USARTs/UARTs whose pins are broken out to headers. */
+#define BOARD_NR_USARTS         3
+
+/* USART pin numbers. */
+#define BOARD_USART1_TX_PIN     7
+#define BOARD_USART1_RX_PIN     8
+#define BOARD_USART2_TX_PIN     1
+#define BOARD_USART2_RX_PIN     0
+#define BOARD_USART3_TX_PIN     29
+#define BOARD_USART3_RX_PIN     30
+
+/* Number of SPI ports broken out to headers. */
+#define BOARD_NR_SPI            2
+
+/* SPI pin numbers. */
+#define BOARD_SPI1_NSS_PIN      10
+#define BOARD_SPI1_MOSI_PIN     11
+#define BOARD_SPI1_MISO_PIN     12
+#define BOARD_SPI1_SCK_PIN      13
+#define BOARD_SPI2_NSS_PIN      31
+#define BOARD_SPI2_MOSI_PIN     34
+#define BOARD_SPI2_MISO_PIN     33
+#define BOARD_SPI2_SCK_PIN      32
+
+/* Total number of GPIO pins that are broken out to headers and
+ * intended for use. This includes pins like the LED, button, and
+ * debug port (JTAG/SWD) pins. */
+#define BOARD_NR_GPIO_PINS      44
+
+/* Number of pins capable of PWM output. */
+#define BOARD_NR_PWM_PINS       8
+
+/* Number of pins capable of ADC conversion. */
+#define BOARD_NR_ADC_PINS       6
+
+/* Number of pins already connected to external hardware.  For Maple,
+ * these are just BOARD_LED_PIN, BOARD_BUTTON_PIN, and the debug port
+ * pins (see below). */
+#define BOARD_NR_USED_PINS       2
+
+/**
+ * Note: there is no USB in this board.
+ */
+
+/* Pin aliases: these give the GPIO port/bit for each pin as an
+ * enum. These are optional, but recommended. They make it easier to
+ * write code using low-level GPIO functionality. */
+enum {
+    PA3, PA2, PA0, PA1, PB5, PB6, PA8, PA9, PA10, PB7, PA4, PA7, PA6, PA5, PB8,
+    PC0, PC1, PC2, PC3, PC4, PC5, PC13, PC14, PC15, PB9, PD2, PC10, PB0, PB1,
+    PB10, PB11, PB12, PB13, PB14, PB15, PC6, PC7, PC8, PC9, PA13, PA14, PA15,
+    PB3, PB4
+};
+
+#endif


### PR DESCRIPTION
This adds support for the NUCLEO-F103RB boards, using changes introduced by @mbolivar allowing boards to override clocks (see #102)

Changes are:
- It adds `.hex` output in the `build/` directory, that is compliant with `openocd`
- It adds comments in the `Makefile` to allow overriding of the `STM32_PCLK*` using CFLAGS
- It adds `nucleo` board support, overriding clocks to use the internal oscillator

Note that since there is no bootloader, you'll also have to run `make jtag` to build a valid image for the board.
