### PR TITLE
Removing clock config because it was incorrect

### DIFF
--- a/wirish/boards/nucleo/board.cpp
+++ b/wirish/boards/nucleo/board.cpp
@@ -49,7 +49,7 @@ void boardInit(void) {
     afio_remap(AFIO_REMAP_TIM2_FULL);
     afio_remap(AFIO_REMAP_TIM3_PARTIAL);
 }
-
+ 
 // Pin map: this lets the basic I/O functions (digitalWrite(),
 // analogRead(), pwmWrite()) translate from pin numbers to STM32
 // peripherals.

--- a/wirish/boards/nucleo/board.cpp
+++ b/wirish/boards/nucleo/board.cpp
@@ -50,14 +50,6 @@ void boardInit(void) {
     afio_remap(AFIO_REMAP_TIM3_PARTIAL);
 }
 
-namespace wirish {
-namespace priv {
-static stm32f1_rcc_pll_data pll_data = {RCC_PLLMUL_9};
-rcc_clk w_board_pll_in_clk = RCC_CLK_HSI;
-rcc_pll_cfg w_board_pll_cfg = {RCC_PLLSRC_HSI_DIV_2, &pll_data};
-}
-}
-
 // Pin map: this lets the basic I/O functions (digitalWrite(),
 // analogRead(), pwmWrite()) translate from pin numbers to STM32
 // peripherals.

--- a/wirish/boards/nucleo/board.cpp
+++ b/wirish/boards/nucleo/board.cpp
@@ -49,7 +49,7 @@ void boardInit(void) {
     afio_remap(AFIO_REMAP_TIM2_FULL);
     afio_remap(AFIO_REMAP_TIM3_PARTIAL);
 }
- 
+
 // Pin map: this lets the basic I/O functions (digitalWrite(),
 // analogRead(), pwmWrite()) translate from pin numbers to STM32
 // peripherals.


### PR DESCRIPTION
-the clock only worked at 36MHz instead of 72MHz as defined elsewhere in
the code.  As a consequence when creating a serial port at 115200baud,
meant it actually only worked on 57600baud.  The same was true for using
delay loops etc.
-by removing the custom clock config, the STM32F103RB is clocked from the 8MHz output of the ST-Link V2 debugger, which has a crystal controlled clock.
-mbed also configures the STM32F103RB to be clocked from the ST-Link V2 debugger